### PR TITLE
refactor: use Vue 3's unmounted hook instead of destroyed

### DIFF
--- a/src/components/InfiniteLoading.vue
+++ b/src/components/InfiniteLoading.vue
@@ -49,6 +49,7 @@
     </div>
   </div>
 </template>
+
 <script>
 import { defineComponent } from 'vue'
 import Spinner from './Spinner.vue';
@@ -337,7 +338,7 @@ export default defineComponent({
       return result || this.getScrollParent(elm.parentNode);
     },
   },
-  destroyed() {
+  unmounted() {
     /* istanbul ignore else */
     if (!this.status !== STATUS.COMPLETE) {
       throttleer.reset();
@@ -347,6 +348,7 @@ export default defineComponent({
   },
 })
 </script>
+
 <style lang="less" scoped>
 @deep: ~'>>>';
 


### PR DESCRIPTION
`destroyed` does not exist in Vue 3. The only way it must be working is in compatibility mode/migration build.

This change makes things compatible with Vue 3, and fixes the following warning in compat mode:

![image](https://github.com/user-attachments/assets/045a1c23-fb8f-483d-a766-c759e52a2007)
